### PR TITLE
Fixed the error of the "foreach" function in the browser. 

### DIFF
--- a/gamepad.js
+++ b/gamepad.js
@@ -37,7 +37,7 @@ class GamepadHandler {
         this.timeout = setTimeout(this.loop.bind(this), 10);
     }
     updateGamepadState() {
-        let gamepads = this.getGamepads();
+        let gamepads = Array.from(this.getGamepads());
         if (!gamepads) return;
         if (!Array.isArray(gamepads) && gamepads.length) {
             let gp = [];


### PR DESCRIPTION
The objects traversed by the “foreach” method should be arrays, and the “Array.from()” method should be used to convert the traversal objects to arrays, ensuring that they run in some more restrictive browsers.